### PR TITLE
Manually 'play()' the stream element as soon as possible.

### DIFF
--- a/src/views/videoplay.js
+++ b/src/views/videoplay.js
@@ -77,8 +77,11 @@ function startVideoSpeechStream() {
     videoProps.stream = WatsonSpeechToText.recognizeElement({
 	element: myMediaElement,
 	token: videoProps.ctx.token,
-	muteSource: true})
-	.pipe(new WatsonSpeechToText.FormatStream());
+	muteSource: true,
+	autoPlay: false
+    })
+    .pipe(new WatsonSpeechToText.FormatStream());
+    myMediaElement.play();
     videoProps.playing = true;
 
     $('<span class="transcript-current-sentence">&nbsp;</span>').appendTo($('.transcript--content'));


### PR DESCRIPTION
This commit changea the 'autoplay' feature of the streaming transcribed element,
to deal with Firefox and the Speech SDK. The Speech SDK, by default, uses a
'canplaythrough' event to trigger transcription. Current Firefox interprets
'canplaythrough' as the entire file needing to be downloaded, which delays the
emission of this event.
