### PR TITLE
Fix alchemylanguage-service name in manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -13,4 +13,4 @@ applications:
   memory: 512M
   services:
   - speech-to-text-service
-  - alchemy-language-service
+  - alchemylanguage-service


### PR DESCRIPTION
Fixes `Could not find service alchemy-language-service to bind to <app name>` on `cf push`